### PR TITLE
point ffmpeg.defaultOutputPath to host media directory

### DIFF
--- a/devenv/local.reach-engine.properties
+++ b/devenv/local.reach-engine.properties
@@ -168,7 +168,7 @@ exiftool.path=/reachengine/utilities/exiftool
 ##       space to store files
 ##
 ffmpeg.path=/usr/local/bin/ffmpeg
-ffmpeg.defaultOutputPath=/media/temp
+ffmpeg.defaultOutputPath=/Users/media/temp
 
 ffprobe.path=/usr/local/bin/ffprobe
 


### PR DESCRIPTION
Fixes the output issues with ffmpeg - still requires that ffmpeg be installed on the host. 